### PR TITLE
Resolve Jekyll interactive errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-paginate'
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
Needed to add an explicit reference to `webrick` in order to get interactive rebuild of the website working - had errors with it both on Windows and on WSL / Ubuntu 20.04