### PR TITLE
Update September 2026 abstract to match revised Meetup copy

### DIFF
--- a/_posts/2026-09-17-you-should-probably-be-using-iasyncenumerable.md
+++ b/_posts/2026-09-17-you-should-probably-be-using-iasyncenumerable.md
@@ -4,26 +4,28 @@ speakers:           ["Aaron Stannard"]
 title:              "You Should Probably Be Using IAsyncEnumerable"
 location:           "Beach Walk Coworking"
 sponsors:           ["Petabridge"]
-description:        "Task tells you a job is pending -- not whether it's alive. Why long-running work belongs in a stream, with three pieces of production code and the point where the thesis breaks."
+description:        "Task can't tell you whether a long-running job is alive or stuck. A better primitive for modeling background jobs, intermittent jobs, and producer-consumer relationships."
 meetup:             "315672505"
 survey-url:         ""
 ---
 
 A job has been running for twenty minutes. Is it working, or is it dead?
 
-You can't tell. Not from the outside. `Task<T>` has three states: pending, completed, faulted. "Alive and making progress" and "wedged forever and never coming back" are the same one. That isn't an observability gap you can instrument your way out of. It's the return type.
+You can't tell. Not from the outside.
 
-Every timeout you've ever wrapped around a long-running call is a confession of this. You guessed a number, because the Task won't say anything until it's over.
+`Task<T>` has three states: pending, completed, faulted. "Alive and making progress" and "stuck forever and never coming back" are the same one. That isn't an observability gap you can instrument your way out of. It's how Task is designed.
 
-`IAsyncEnumerable<T>` isn't a sequence you await. It's a producer / consumer contract, and a thing that unfolds over time can tell you it's still unfolding. An element arriving is proof of life.
+What we need is a better primitive for modeling longer running background jobs, intermittent jobs, and producer-consumer relationships. Enter `IAsyncEnumerable`, which allows us to model these tasks as asynchronous *streaming* jobs.
 
-You may already be writing this without having decided to. `TypedResults.ServerSentEvents` takes an `IAsyncEnumerable<SseItem<T>>`.
+`IAsyncEnumerable<T>` isn't a sequence you await. It's a producer / consumer contract - you know it's alive when new events arrive during the *progression* of the job, rather than at its completion.
 
-Three pieces of Petabridge production code, all public. An AI agent that runs two timers over its own token stream, so it can tell "nothing arrived, it's dead" from "heartbeats arriving, zero real output, it's alive and stuck." A 20-minute re-embedding job that streams progress over SSE, where a late subscriber's first element is the current state. And a checkout that polled every 200ms, 3,738ms cold, until it stopped polling and started subscribing.
+In this talk we'll look at several examples of .NET code where `IAsyncEnumerable` is crucial to ensure the success of the application:
 
-Then I'll break my own thesis. `IAsyncEnumerable` backpressures the consumer and barely touches the producer. Channels do it weakly, and I'll show you my own code hand-rolling a 500ms throttle to hide that. Some producers can't be slowed at all: the Claude API streaming tokens at you, Kafka, the physical world. Then your only honest move is an explicit lossy policy.
+- AI agent that runs two timers over its own token stream, so it can distinguish "nothing arrived, it's dead" scenarios from "heartbeats arriving, zero real output, it's alive and stuck."
+- A 20-minute re-embedding job that streams progress over ASP.NET Core SSE, where a late subscriber's first element is the current state.
+- And an e-commerce checkout page that used to poll for proof of fulfillment / payment activity, that now instead waits for events via SSE to drive navigation and behavior from the back-end.
 
-You'll leave knowing which Tasks in your codebase should have been streams.
+You'll learn how and where to apply `IAsyncEnumerable` to solve your problems.
 
 ## Food / Drinks
 Food and drinks will be provided! Please contact us (on meetup) if you have any dietary restrictions/food allergies.


### PR DESCRIPTION
Syncs the website post with the abstract Aaron revised directly on Meetup.

- Tightened opening, examples now a bulleted list
- Unicode angle brackets (a Meetup sanitizer workaround) converted back to real `Task<T>` / `IAsyncEnumerable<T>` code spans
- Meetup editor's backslash escapes stripped
- Fixed "asynchrnonous" typo (still present in the Meetup copy)
- Frontmatter `description` updated to match the new framing

Jekyll build passes.