### PR TITLE
Add October 2026 meetup: Bridging IEnumerable and IObservable with Dynamic Data

### DIFF
--- a/_posts/2026-10-22-bridging-ienumerable-and-iobservable-with-dynamic-data.md
+++ b/_posts/2026-10-22-bridging-ienumerable-and-iobservable-with-dynamic-data.md
@@ -1,0 +1,21 @@
+---
+date:               "2026-10-22 17:30:00"
+speakers:           ["Rodney Littles, II"]
+title:              "Bridging IEnumerable and IObservable with Dynamic Data"
+location:           "Beach Walk Coworking"
+sponsors:           ["Petabridge"]
+description:        "Dynamic Data bridges IEnumerable and IObservable, giving you reactive operators — Filter, Transform, Sort, AutoRefresh, Batch — that pipe collection changes straight to the UI."
+meetup:             "316119800"
+survey-url:         ""
+---
+
+You've bound a list, updated an item's property, and watched the UI do nothing. That gap in `ObservableCollection<T>` is by design: binding a list requires `INotifyCollectionChanged` — not just `INotifyPropertyChanged` — and out of the box the two don't compose. Dynamic Data, created by Roland Pheasant and now a dependency of ReactiveUI, bridges `IEnumerable` and `IObservable` by projecting change sets out of your collections. With a `SourceCache<T, TKey>` or `SourceList<T>` at the core, you get reactive operators — Filter, Transform, Sort, AutoRefresh, Batch — that can be driven by other observables. Want the list to re-sort every time a picker selection changes? That's one operator. Want property changes inside list items to trigger a new sort pass? That's one operator. In this session we'll demonstrate a few working view models that connect to a data source and pipe changes all the way to the UI — without a single `foreach`, event handler, or manual `ObservableCollection` reassignment.
+
+*Difficulty: Intermediate — helpful to know C#, MVVM, and Reactive Extensions basics going in.*
+
+## Food / Drinks
+Food and drinks will be provided! Please contact us (on meetup) if you have any dietary restrictions/food allergies.
+
+## Directions and Parking Instructions
+
+Meeting will be held at Beach Walk Coworking, 96 Beach Walk Blvd, Conroe, TX 77304 in the ground floor meeting room. Free parking is available on site.


### PR DESCRIPTION
## Summary
- Adds the October 22, 2026 meeting post: Rodney Littles, II presenting "Bridging IEnumerable and IObservable with Dynamic Data"
- Links to Meetup event 316119800 (currently DRAFT)
- Speaker profile already exists at `_persons/rodney-littles-ii.md`, no changes needed

## Notes
- **Do not merge until the Meetup event is published.** The post's `meetup` frontmatter becomes an RSVP link, and a DRAFT event returns 404 to the public.
- This meeting is scheduled slightly out of the usual 3rd-Thursday cadence per Aaron's calendar constraints.

## Test plan
- [x] `bundle exec jekyll build` succeeds, post renders at `_site/meetings/2026/10/22/`
- [ ] Publish the Meetup event, then merge this PR